### PR TITLE
Fix tab complete shortcut

### DIFF
--- a/cookbook/A quick tour of IPython Notebook.ipynb
+++ b/cookbook/A quick tour of IPython Notebook.ipynb
@@ -55,7 +55,7 @@
      "source": [
       "One of the most useful things about IPython notebook is its tab completion. \n",
       "\n",
-      "Try this: click just after read_csv( in the cell below and press tab 4 times, slowly"
+      "Try this: click just after read_csv( in the cell below and press Shift+Tab (or Tab if you're using IPython 1.x) 4 times, slowly"
      ]
     },
     {
@@ -92,7 +92,7 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "I find this amazingly useful. I think of this as \"the more confused I am, the more times I should press tab\". Nothing bad will happen if you press tab 12 times.\n",
+      "I find this amazingly useful. I think of this as \"the more confused I am, the more times I should press Shift+Tab\". Nothing bad will happen if you tab complete 12 times.\n",
       "\n",
       "Okay, let's try tab completion for function names!"
      ]


### PR DESCRIPTION
Tab complete shortcut has changed in IPython 2.0. This fixes issue #15.
