### PR TITLE
Dockerise

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ RUN mkdir /pandas-cookbook
 WORKDIR /pandas-cookbook
 RUN mkdir ./cookbook ./data ./cookbook/images
 
-COPY cookbook/* ./cookbook/
-COPY cookbook/images/* ./cookbook/images/
+COPY cookbook/*.ipynb ./cookbook/
+COPY cookbook/images/*.png ./cookbook/images/
 COPY data/* ./data/
 
 WORKDIR /pandas-cookbook/cookbook/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM ipython/scipyserver
+
+RUN mkdir /pandas-cookbook
+WORKDIR /pandas-cookbook
+RUN mkdir ./cookbook ./data ./cookbook/images
+
+COPY cookbook/* ./cookbook/
+COPY cookbook/images/* ./cookbook/images/
+COPY data/* ./data/
+
+WORKDIR /pandas-cookbook/cookbook/

--- a/README.md
+++ b/README.md
@@ -75,6 +75,28 @@ A tab should open up in your browser at `http://localhost:8888`
 
 Happy pandas!
 
+Running the cookbook inside Docker container.
+===============================================================
+This repository contains Dockerfile and can be build into a docker container.
+To build the container run following command from inside of the repository directory:
+```
+docker build -t jvns/pandas-cookbook .
+```
+run the container:
+```
+docker run -d -p 8888:8888 -e "PASSWORD=MakeAPassword" <IMAGE ID>
+```
+you can find out about the id of the image, by checking
+```
+docker images
+```
+
+After starting the container, you can access ipython notebook with the cookbook
+on port 8888. Remember to use https and authenticate with `MakeAPassword`.
+```
+https://<docker ip>:8888
+```
+
 Contribute!
 ===========
 


### PR DESCRIPTION
I've added a Docker file to build a docker image with ipython and cookbook in it.
I've also added the description on how to use it in `README.md`.
You can connect your jvns/pandas-cookbook repository with respective repository on hub.docker and it will build fully functional container with ipython and cookbook. That way no one will need to build the image themselves locally, just run `docker pull jvns/pandas cookbook`.