### PR TITLE
Fix broken link on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Pandas cookbook
-===============
+# Pandas cookbook
 
 [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/jvns/pandas-cookbook/master)
 
@@ -16,40 +15,37 @@ that entails.
 
 It uses 3 datasets:
 
-* 311 calls in New York
-* How many people were on Montréal's bike paths in 2012
-* Montreal's weather for 2012, hourly
+- 311 calls in New York
+- How many people were on Montréal's bike paths in 2012
+- Montreal's weather for 2012, hourly
 
 It comes with batteries (data) included, so you can try out all the
 examples right away.
 
-Table of Contents
-=================
+# Table of Contents
 
-
-* [A quick tour of the Jupyter Notebook](http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/master/cookbook/A%20quick%20tour%20of%20%20Notebook.ipynb)
+- [A quick tour of the Jupyter Notebook](https://nbviewer.org/github/jvns/pandas-cookbook/blob/master/cookbook/A%20quick%20tour%20of%20IPython%20Notebook.ipynb)
   <br> Shows off Jupyter's awesome tab completion and magic functions.
-* [Chapter 1: Reading from a CSV](http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/master/cookbook/Chapter%201%20-%20Reading%20from%20a%20CSV.ipynb)
+- [Chapter 1: Reading from a CSV](http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/master/cookbook/Chapter%201%20-%20Reading%20from%20a%20CSV.ipynb)
   <br> Reading your data into pandas is pretty much the easiest thing. Even when the encoding is wrong!
-* [Chapter 2: Selecting data & finding the most common complaint type](http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/master/cookbook/Chapter%202%20-%20Selecting%20data%20&%20finding%20the%20most%20common%20complaint%20type.ipynb)
+- [Chapter 2: Selecting data & finding the most common complaint type](http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/master/cookbook/Chapter%202%20-%20Selecting%20data%20&%20finding%20the%20most%20common%20complaint%20type.ipynb)
   <br>It's not totally obvious how to select data from a pandas dataframe. Here I explain the basics (how to take slices and get columns)
-* [Chapter 3: Which borough has the most noise complaints? (or, more selecting data)](http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/master/cookbook/Chapter%203%20-%20Which%20borough%20has%20the%20most%20noise%20complaints%20%28or%2C%20more%20selecting%20data%29.ipynb)
+- [Chapter 3: Which borough has the most noise complaints? (or, more selecting data)](http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/master/cookbook/Chapter%203%20-%20Which%20borough%20has%20the%20most%20noise%20complaints%20%28or%2C%20more%20selecting%20data%29.ipynb)
   <br>Here we get into serious slicing and dicing and learn how to filter dataframes in complicated ways, really fast.
-* [Chapter 4: Find out on which weekday people bike the most with groupby and aggregate](http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/master/cookbook/Chapter%204%20-%20Find%20out%20on%20which%20weekday%20people%20bike%20the%20most%20with%20groupby%20and%20aggregate.ipynb)
+- [Chapter 4: Find out on which weekday people bike the most with groupby and aggregate](http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/master/cookbook/Chapter%204%20-%20Find%20out%20on%20which%20weekday%20people%20bike%20the%20most%20with%20groupby%20and%20aggregate.ipynb)
   <br> The groupby/aggregate is seriously my favorite thing about pandas and I use it all the time. You should probably read this.
-* [Chapter 5: Combining dataframes and scraping Canadian weather data](http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/master/cookbook/Chapter%205%20-%20Combining%20dataframes%20and%20scraping%20Canadian%20weather%20data.ipynb)
+- [Chapter 5: Combining dataframes and scraping Canadian weather data](http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/master/cookbook/Chapter%205%20-%20Combining%20dataframes%20and%20scraping%20Canadian%20weather%20data.ipynb)
   <br>Here you get to find out if it's cold in Montreal in the winter (spoiler: yes). Web scraping with pandas is fun!
-* [Chapter 6: String operations! Which month was the snowiest?](http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/master/cookbook/Chapter%206%20-%20String%20Operations-%20Which%20month%20was%20the%20snowiest.ipynb)
+- [Chapter 6: String operations! Which month was the snowiest?](http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/master/cookbook/Chapter%206%20-%20String%20Operations-%20Which%20month%20was%20the%20snowiest.ipynb)
   <br> Strings with pandas are great. It has all these vectorized string operations and they're the best. We will turn a bunch of strings containing "Snow" into vectors of numbers in a trice.
-* [Chapter 7: Cleaning up messy data](http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/master/cookbook/Chapter%207%20-%20Cleaning%20up%20messy%20data.ipynb)
+- [Chapter 7: Cleaning up messy data](http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/master/cookbook/Chapter%207%20-%20Cleaning%20up%20messy%20data.ipynb)
   <br> Cleaning up messy data is never a joy, but with pandas it's easier &lt;3
-* [Chapter 8: Parsing Unix timestamps](http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/master/cookbook/Chapter%208%20-%20How%20to%20deal%20with%20timestamps.ipynb)
+- [Chapter 8: Parsing Unix timestamps](http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/master/cookbook/Chapter%208%20-%20How%20to%20deal%20with%20timestamps.ipynb)
   <br> This is basically a quick trick that took me 2 days to figure out.
-* [Chapter 9 - Loading data from SQL databases](http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/master/cookbook/Chapter%209%20-%20Loading%20data%20from%20SQL%20databases.ipynb)
+- [Chapter 9 - Loading data from SQL databases](http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/master/cookbook/Chapter%209%20-%20Loading%20data%20from%20SQL%20databases.ipynb)
   <br> How to load data from an SQL database into Pandas, with examples using SQLite3, PostgreSQL, and MySQL.
 
-How to use this cookbook
-========================
+# How to use this cookbook
 
 The easiest way is to try it out instantly online using Binder's awesome service. **[Start by clicking here](https://mybinder.org/v2/gh/jvns/pandas-cookbook/master)**, wait for it to launch, then click on "cookbook", and you'll be off to the races! It will let you run all the code interactively without having to install anything on your computer.
 
@@ -78,27 +74,31 @@ A tab should open up in your browser at `http://localhost:8888`
 
 Happy pandas!
 
-Running the cookbook inside a Docker container.
-===============================================================
+# Running the cookbook inside a Docker container.
+
 This repository contains a Dockerfile and can be built into a docker container.
 To build the container run following command from inside of the repository directory:
+
 ```
 docker build -t jvns/pandas-cookbook -f Dockerfile-Local .
 ```
+
 run the container:
+
 ```
 docker run -d -p 8888:8888 -e "PASSWORD=MakeAPassword" <IMAGE ID>
 ```
+
 you can find out about the id of the image, by checking
+
 ```
 docker images
 ```
 
 After starting the container, you can access the Jupyter notebook with the cookbook
-on port 8888. 
+on port 8888.
 
-License
-=======
+# License
 
 <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="http://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a><br />
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# Pandas cookbook
+Pandas cookbook
+===============
 
 [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/jvns/pandas-cookbook/master)
 
@@ -15,37 +16,40 @@ that entails.
 
 It uses 3 datasets:
 
-- 311 calls in New York
-- How many people were on Montréal's bike paths in 2012
-- Montreal's weather for 2012, hourly
+* 311 calls in New York
+* How many people were on Montréal's bike paths in 2012
+* Montreal's weather for 2012, hourly
 
 It comes with batteries (data) included, so you can try out all the
 examples right away.
 
-# Table of Contents
+Table of Contents
+=================
 
-- [A quick tour of the Jupyter Notebook](https://nbviewer.org/github/jvns/pandas-cookbook/blob/master/cookbook/A%20quick%20tour%20of%20IPython%20Notebook.ipynb)
+
+* [A quick tour of the Jupyter Notebook](https://nbviewer.org/github/jvns/pandas-cookbook/blob/master/cookbook/A%20quick%20tour%20of%20IPython%20Notebook.ipynb)
   <br> Shows off Jupyter's awesome tab completion and magic functions.
-- [Chapter 1: Reading from a CSV](http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/master/cookbook/Chapter%201%20-%20Reading%20from%20a%20CSV.ipynb)
+* [Chapter 1: Reading from a CSV](http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/master/cookbook/Chapter%201%20-%20Reading%20from%20a%20CSV.ipynb)
   <br> Reading your data into pandas is pretty much the easiest thing. Even when the encoding is wrong!
-- [Chapter 2: Selecting data & finding the most common complaint type](http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/master/cookbook/Chapter%202%20-%20Selecting%20data%20&%20finding%20the%20most%20common%20complaint%20type.ipynb)
+* [Chapter 2: Selecting data & finding the most common complaint type](http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/master/cookbook/Chapter%202%20-%20Selecting%20data%20&%20finding%20the%20most%20common%20complaint%20type.ipynb)
   <br>It's not totally obvious how to select data from a pandas dataframe. Here I explain the basics (how to take slices and get columns)
-- [Chapter 3: Which borough has the most noise complaints? (or, more selecting data)](http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/master/cookbook/Chapter%203%20-%20Which%20borough%20has%20the%20most%20noise%20complaints%20%28or%2C%20more%20selecting%20data%29.ipynb)
+* [Chapter 3: Which borough has the most noise complaints? (or, more selecting data)](http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/master/cookbook/Chapter%203%20-%20Which%20borough%20has%20the%20most%20noise%20complaints%20%28or%2C%20more%20selecting%20data%29.ipynb)
   <br>Here we get into serious slicing and dicing and learn how to filter dataframes in complicated ways, really fast.
-- [Chapter 4: Find out on which weekday people bike the most with groupby and aggregate](http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/master/cookbook/Chapter%204%20-%20Find%20out%20on%20which%20weekday%20people%20bike%20the%20most%20with%20groupby%20and%20aggregate.ipynb)
+* [Chapter 4: Find out on which weekday people bike the most with groupby and aggregate](http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/master/cookbook/Chapter%204%20-%20Find%20out%20on%20which%20weekday%20people%20bike%20the%20most%20with%20groupby%20and%20aggregate.ipynb)
   <br> The groupby/aggregate is seriously my favorite thing about pandas and I use it all the time. You should probably read this.
-- [Chapter 5: Combining dataframes and scraping Canadian weather data](http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/master/cookbook/Chapter%205%20-%20Combining%20dataframes%20and%20scraping%20Canadian%20weather%20data.ipynb)
+* [Chapter 5: Combining dataframes and scraping Canadian weather data](http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/master/cookbook/Chapter%205%20-%20Combining%20dataframes%20and%20scraping%20Canadian%20weather%20data.ipynb)
   <br>Here you get to find out if it's cold in Montreal in the winter (spoiler: yes). Web scraping with pandas is fun!
-- [Chapter 6: String operations! Which month was the snowiest?](http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/master/cookbook/Chapter%206%20-%20String%20Operations-%20Which%20month%20was%20the%20snowiest.ipynb)
+* [Chapter 6: String operations! Which month was the snowiest?](http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/master/cookbook/Chapter%206%20-%20String%20Operations-%20Which%20month%20was%20the%20snowiest.ipynb)
   <br> Strings with pandas are great. It has all these vectorized string operations and they're the best. We will turn a bunch of strings containing "Snow" into vectors of numbers in a trice.
-- [Chapter 7: Cleaning up messy data](http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/master/cookbook/Chapter%207%20-%20Cleaning%20up%20messy%20data.ipynb)
+* [Chapter 7: Cleaning up messy data](http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/master/cookbook/Chapter%207%20-%20Cleaning%20up%20messy%20data.ipynb)
   <br> Cleaning up messy data is never a joy, but with pandas it's easier &lt;3
-- [Chapter 8: Parsing Unix timestamps](http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/master/cookbook/Chapter%208%20-%20How%20to%20deal%20with%20timestamps.ipynb)
+* [Chapter 8: Parsing Unix timestamps](http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/master/cookbook/Chapter%208%20-%20How%20to%20deal%20with%20timestamps.ipynb)
   <br> This is basically a quick trick that took me 2 days to figure out.
-- [Chapter 9 - Loading data from SQL databases](http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/master/cookbook/Chapter%209%20-%20Loading%20data%20from%20SQL%20databases.ipynb)
+* [Chapter 9 - Loading data from SQL databases](http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/master/cookbook/Chapter%209%20-%20Loading%20data%20from%20SQL%20databases.ipynb)
   <br> How to load data from an SQL database into Pandas, with examples using SQLite3, PostgreSQL, and MySQL.
 
-# How to use this cookbook
+How to use this cookbook
+========================
 
 The easiest way is to try it out instantly online using Binder's awesome service. **[Start by clicking here](https://mybinder.org/v2/gh/jvns/pandas-cookbook/master)**, wait for it to launch, then click on "cookbook", and you'll be off to the races! It will let you run all the code interactively without having to install anything on your computer.
 
@@ -74,31 +78,27 @@ A tab should open up in your browser at `http://localhost:8888`
 
 Happy pandas!
 
-# Running the cookbook inside a Docker container.
-
+Running the cookbook inside a Docker container.
+===============================================================
 This repository contains a Dockerfile and can be built into a docker container.
 To build the container run following command from inside of the repository directory:
-
 ```
 docker build -t jvns/pandas-cookbook -f Dockerfile-Local .
 ```
-
 run the container:
-
 ```
 docker run -d -p 8888:8888 -e "PASSWORD=MakeAPassword" <IMAGE ID>
 ```
-
 you can find out about the id of the image, by checking
-
 ```
 docker images
 ```
 
 After starting the container, you can access the Jupyter notebook with the cookbook
-on port 8888.
+on port 8888. 
 
-# License
+License
+=======
 
 <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="http://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a><br />
 


### PR DESCRIPTION
Fixes broken link on README that went to "A quick tour of IPython Notebook". This is the correct link: https://nbviewer.org/github/jvns/pandas-cookbook/blob/master/cookbook/A%20quick%20tour%20of%20IPython%20Notebook.ipynb

fixes #82 