### PR TITLE
Fix MyBinder build issue with package version compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-matplotlib==3.7.1
+matplotlib==3.4.3
 numpy==1.22.3
 pandas==1.4.2
 jupyter==1.0.0


### PR DESCRIPTION
This pull request resolves the little issue with the MyBinder build process failing due to version incompatibility with matplotlib. The changes include:

1. Updating the requirements.txt file to use matplotlib==3.4.3, which is compatible with the current Python version.

Changes made:

1. Updated requirements.txt to matplotlib==3.4.3.

Tested the changes locally to ensure the environment builds successfully and all dependencies are installed correctly.

Please review the changes and provide any feedback.